### PR TITLE
Get all variables, not just first 20

### DIFF
--- a/glen/variables.go
+++ b/glen/variables.go
@@ -87,8 +87,10 @@ func (v *Variables) Init() error {
 
 	// Get the project variables and add them to v.Env
 	projectVariablesOpt := &gitlab.ListProjectVariablesOptions{
-		PerPage: variablesPerPage,
-		Page:    1,
+		ListOptions: gitlab.ListOptions{
+			PerPage: variablesPerPage,
+			Page:    1,
+		}
 	}
 
 	for {

--- a/glen/variables.go
+++ b/glen/variables.go
@@ -47,7 +47,7 @@ func (v *Variables) Init() error {
 	var err error
 
 	// Initialize the GitLab client
-	glURL := "https://" + v.Repo.BaseURL + "/api/v4"
+	glURL := fmt.Sprintf("https://%s/api/v4", v.Repo.BaseURL)
 	glc, err := gitlab.NewClient(v.apiKey, gitlab.WithBaseURL(glURL))
 	if err != nil {
 		return fmt.Errorf("failed to create gitlab client: %w", err)

--- a/glen/variables.go
+++ b/glen/variables.go
@@ -47,7 +47,8 @@ func (v *Variables) Init() error {
 	var err error
 
 	// Initialize the GitLab client
-	glc, err := gitlab.NewClient(v.apiKey, gitlab.WithBaseURL("https://"+v.Repo.BaseURL+"/api/v4"))
+	glURL := "https://" + v.Repo.BaseURL + "/api/v4"
+	glc, err := gitlab.NewClient(v.apiKey, gitlab.WithBaseURL(glURL))
 	if err != nil {
 		return fmt.Errorf("failed to create gitlab client: %w", err)
 	}

--- a/glen/variables.go
+++ b/glen/variables.go
@@ -60,10 +60,11 @@ func (v *Variables) Init() error {
 
 	// Get variables from the parent groups, if recurse
 	if v.Recurse {
-
 		groupVariablesOpt := &gitlab.ListGroupVariablesOptions{
-			PerPage: variablesPerPage,
-			Page:    1,
+			ListOptions: gitlab.ListOptions{
+				PerPage: variablesPerPage,
+				Page:    1,
+			}
 		}
 
 		for _, group := range v.Repo.Groups {


### PR DESCRIPTION
By default GitLab returns only the first 20 variables unless pagination is used on the API: https://docs.gitlab.com/ee/api/README.html#offset-based-pagination

This PR adds the required pagination.

I'm still fairly new to golang, so I'm very open to any feedback! :)

Fixes #35 