### PR TITLE
Check if API key has been set and exit with error message if not.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/lingrino/glen/glen"
 	"github.com/spf13/cobra"
@@ -18,18 +19,14 @@ const (
 )
 
 func glenCmd() *cobra.Command {
-	// recurse determines if glen with also get variables from the project's parent groups
-	var recurse bool
-	// apiKey is the GitLab key that we should use when calling the API
-	var apiKey string
-	// directory is the path to the git repo that we should run glen on
-	var directory string
-	// remoteName is the name of the GitLab remote in your git repo
-	var remoteName string
-	// outputFormat is the text format that we should use to print our results to stdout
-	var outputFormat string
-	// groupOnly determines if glen only gets variables from the project's parent groups
-	var groupOnly bool
+	var (
+		recurse      bool   // recurse determines if glen with also get variables from the project's parent groups
+		apiKey       string // apiKey is the GitLab key that we should use when calling the API
+		directory    string // directory is the path to the git repo that we should run glen on
+		remoteName   string // remoteName is the name of the GitLab remote in your git repo
+		outputFormat string // outputFormat is the text format that we should use to print our results to stdout
+		groupOnly    bool   // groupOnly determines if glen only gets variables from the project's parent groups
+	)
 
 	cmd := &cobra.Command{
 		Use:   "glen",
@@ -58,6 +55,11 @@ variables and the variables of every parent group.`,
 			vars.Recurse = recurse
 			if apiKey != "GITLAB_TOKEN" {
 				vars.SetAPIKey(apiKey)
+			}
+
+			if !vars.IsAPIKeySet() {
+				fmt.Println("GitLab API key not set. Please use --api-key/-k flag or set GITLAB_TOKEN environment variable.")
+				os.Exit(1)
 			}
 
 			err = vars.Init()

--- a/glen/variables.go
+++ b/glen/variables.go
@@ -47,6 +47,11 @@ func (v *Variables) SetAPIKey(key string) {
 	v.apiKey = key
 }
 
+// Check if apiKey is set to a non-empty value.
+func (v *Variables) IsAPIKeySet() bool {
+	return v.apiKey != ""
+}
+
 // Get the group variables and add them to v.Env.
 func (v *Variables) getGroupVariables(glc *gitlab.Client, group string) error {
 	groupVariablesOpt := &gitlab.ListGroupVariablesOptions{

--- a/glen/variables.go
+++ b/glen/variables.go
@@ -47,7 +47,7 @@ func (v *Variables) SetAPIKey(key string) {
 	v.apiKey = key
 }
 
-// Check if apiKey is set to a non-empty value.
+// IsAPIKeySet checks if apiKey is set to a non-empty value.
 func (v *Variables) IsAPIKeySet() bool {
 	return v.apiKey != ""
 }


### PR DESCRIPTION
- Adds `IsAPIKeySet` function to verify that the api key is not an empty string.
- Exits with an error message and exit status of 1 if api key is not set.
- I refactored the variable definitions in `glenCmd()` to stay within the function length set by golangci-lint.

Fixes #169 